### PR TITLE
add zenodo citation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,7 @@ Workflow B
 
 # License
 The post-wildfire-recovery project is under the [MIT License](https://github.com/AreteY/post-wildfire-recovery/blob/main/LICENSE.md).
+
+# Zenodo Citation
+[![DOI](https://zenodo.org/badge/485825368.svg)](https://zenodo.org/badge/latestdoi/485825368)
+


### PR DESCRIPTION
The problem to this is it links to my fork... but at least the structure is there and @AreteY you should just be able to get your specific url and edit. also, not sure if it is in the right place in the readme